### PR TITLE
Bug: regional date format not read successfully

### DIFF
--- a/AbeckDev.Dlrgdd.RegistrationTool.Functions/AbeckDev.Dlrgdd.RegistrationTool.Functions.csproj
+++ b/AbeckDev.Dlrgdd.RegistrationTool.Functions/AbeckDev.Dlrgdd.RegistrationTool.Functions.csproj
@@ -2,7 +2,7 @@
   <PropertyGroup>
     <TargetFramework>netcoreapp3.1</TargetFramework>
     <AzureFunctionsVersion>v3</AzureFunctionsVersion>
-    <Version>0.1.2</Version>
+    <Version>0.1.3</Version>
     <Authors>AbeckDev</Authors>
     <Company>DLRG Bezirk Dresden e. V.</Company>
     <Description>A set of functions used to validate and handle user registration of events with an Azure Service Bus and Storage Account backend.</Description>

--- a/AbeckDev.Dlrgdd.RegistrationTool.Functions/EventMetadataFunction.cs
+++ b/AbeckDev.Dlrgdd.RegistrationTool.Functions/EventMetadataFunction.cs
@@ -20,7 +20,7 @@ namespace AbeckDev.Dlrgdd.RegistrationTool.Functions
             ILogger log)
         {
             log.LogInformation("C# HTTP trigger function processed a request.");
-
+            
             //Get MetaInformationService
             var metaInformationService = new MetaInformationService();
 

--- a/AbeckDev.Dlrgdd.RegistrationTool.Functions/Services/MetaInformationService.cs
+++ b/AbeckDev.Dlrgdd.RegistrationTool.Functions/Services/MetaInformationService.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Collections.Generic;
+using System.Globalization;
 using System.Reflection;
 using System.Text;
 
@@ -15,7 +16,7 @@ namespace AbeckDev.Dlrgdd.RegistrationTool.Functions.Services
 
             var dummy = debug;
 
-            if (DateTime.TryParse(System.Environment.GetEnvironmentVariable("EventRegistrationDeadline"),out DateTime Deadline))
+            if (DateTime.TryParseExact(System.Environment.GetEnvironmentVariable("EventRegistrationDeadline"),"dd.MM.yyyy",CultureInfo.InvariantCulture,DateTimeStyles.None, out DateTime Deadline))
             {
                 return Deadline;
             }

--- a/AbeckDev.Dlrgdd.RegistrationTool.Functions/Services/MetaInformationService.cs
+++ b/AbeckDev.Dlrgdd.RegistrationTool.Functions/Services/MetaInformationService.cs
@@ -12,10 +12,6 @@ namespace AbeckDev.Dlrgdd.RegistrationTool.Functions.Services
         public DateTime GetEventRegistrationDeadline()
         {
 
-            var debug = System.Environment.GetEnvironmentVariable("EventRegistrationDeadline");
-
-            var dummy = debug;
-
             if (DateTime.TryParseExact(System.Environment.GetEnvironmentVariable("EventRegistrationDeadline"),"dd.MM.yyyy",CultureInfo.InvariantCulture,DateTimeStyles.None, out DateTime Deadline))
             {
                 return Deadline;

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ The Function Backend needs the follwing settings to be parsed as Environment Var
 
 | Config Flag                         | SampleValue                            | Description                                                                                                                                        |
 |-------------------------------------|----------------------------------------|----------------------------------------------------------------------------------------------------------------------------------------------------|
-| EventRegistrationDeadline           | 07.06.2021                             | The Registration Deadline. If that date is passed, no further registration is possible.                                                            |
+| EventRegistrationDeadline           | 07.06.2021                             | The Registration Deadline. If that date is passed, no further registration is possible. Needs to be in format: ```dd.MM.yyyy```                                                            |
 | SendInBlueApiKey                    | RandomString                         | The API Key from the SendInBlue Account which will be used as E-Mail provider.                                                                     |
 | RegistrationSucceededMailTemplateId | 1                                      | The Number of the SendInBlue E-Mail Template which will be used for E-Mail Notification after a successful registration                            |
 | eMailNameFrom                       | MyOrganization - MyEvent               | The Name from which the E-Mail should be from.                                                                                                     |


### PR DESCRIPTION
We fixed the issue that the regional Format dd.MM.yyyy of the Event Deadline Variable was not recognized by the US format based Azure Function. 

We implemented an explicit setting, which will now enforce the german format for the event deadline. 
This is also noted in the readme

fixes #20 